### PR TITLE
treewide: use explicit getAttrOrDefault<std::string>

### DIFF
--- a/src/BarrelCalorimeterInterlayers_geo.cpp
+++ b/src/BarrelCalorimeterInterlayers_geo.cpp
@@ -178,8 +178,8 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, xml_com
   double      f_radius                     = getAttrOrDefault(x_fiber, _U(radius), 0.1 * cm);
   double      f_spacing_x                  = getAttrOrDefault(x_fiber, _Unicode(spacing_x), 0.122 * cm);
   double      f_spacing_z                  = getAttrOrDefault(x_fiber, _Unicode(spacing_z), 0.134 * cm);
-  std::string f_id_grid                    = getAttrOrDefault(x_fiber, _Unicode(identifier_grid), "grid");
-  std::string f_id_fiber                   = getAttrOrDefault(x_fiber, _Unicode(identifier_fiber), "fiber");
+  std::string f_id_grid                    = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_grid), "grid");
+  std::string f_id_fiber                   = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_fiber), "fiber");
 
   // Set up the readout grid for the fiber layers
   // Trapezoid is divided into segments with equal dz and equal number of divisions in x

--- a/src/CompositeTracker_geo.cpp
+++ b/src/CompositeTracker_geo.cpp
@@ -33,7 +33,7 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t)
   sdet.setType("compound");
   xml::setDetectorTypeFlag(e, sdet);
 
-  const std::string actsType = getAttrOrDefault(x_det, _Unicode(actsType), "endcap");
+  const std::string actsType = getAttrOrDefault<std::string>(x_det, _Unicode(actsType), "endcap");
   printout(DEBUG, det_name, "+++ Creating composite tracking detector (type: " + actsType + ")");
   assert(actsType == "barrel" || actsType == "endcap");
 

--- a/src/GaseousRICH_geo.cpp
+++ b/src/GaseousRICH_geo.cpp
@@ -60,7 +60,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   double rmax2        = dims.attr<double>(_Unicode(rmax2));
   double snout_length = dims.attr<double>(_Unicode(snout_length));
   // fill envelope with radiator materials (need optical property for optical photons)
-  auto gasMat = desc.material(dd4hep::getAttrOrDefault(detElem, _Unicode(gas), "AirOptical"));
+  auto gasMat = desc.material(dd4hep::getAttrOrDefault<std::string>(detElem, _Unicode(gas), "AirOptical"));
 
   Cone snout(snout_length / 2.0, rmin, rmax0, rmin, rmax1);
   Tube tank(rmin, rmax2, (length - snout_length) / 2., 0., 2 * M_PI);
@@ -109,7 +109,7 @@ void build_mirrors(Detector& desc, DetElement& sdet, Volume& env, xml::Component
 
   // optical surface
   OpticalSurfaceManager surfMgr = desc.surfaceManager();
-  auto surf = surfMgr.opticalSurface(dd4hep::getAttrOrDefault(plm, _Unicode(surface), "MirrorOpticalSurface"));
+  auto surf = surfMgr.opticalSurface(dd4hep::getAttrOrDefault<std::string>(plm, _Unicode(surface), "MirrorOpticalSurface"));
 
   // placements
   auto gpos = get_xml_xyz(plm, _Unicode(position)) + offset;

--- a/src/HomogeneousCalorimeter_geo.cpp
+++ b/src/HomogeneousCalorimeter_geo.cpp
@@ -360,7 +360,7 @@ static std::tuple<int, int> add_lines(Detector& desc, Assembly& env, xml::Collec
                  dd4hep::getAttrOrDefault<double>(pl, _Unicode(roty), 0.),
                  dd4hep::getAttrOrDefault<double>(pl, _Unicode(rotz), 0.));
     // determine axis
-    std::string axis = dd4hep::getAttrOrDefault(pl, _Unicode(axis), "x");
+    std::string axis = dd4hep::getAttrOrDefault<std::string>(pl, _Unicode(axis), "x");
     std::transform(axis.begin(), axis.end(), axis.begin(), [](char c) { return std::tolower(c); });
     if ((axis != "x") && (axis != "y") && (axis != "z")) {
       std::cerr << "HomogeneousCalorimeter Error: cannot determine axis of line " << axis

--- a/src/MRich_geo.cpp
+++ b/src/MRich_geo.cpp
@@ -137,7 +137,7 @@ static Ref_t createDetector(Detector& description, xml::Handle_t e, SensitiveDet
 
     // optical surfaces
     auto aerogel_surf =
-        surfMgr.opticalSurface(dd4hep::getAttrOrDefault(x_aerogel, _Unicode(surface), "MRICH_AerogelOpticalSurface"));
+        surfMgr.opticalSurface(dd4hep::getAttrOrDefault<std::string>(x_aerogel, _Unicode(surface), "MRICH_AerogelOpticalSurface"));
     SkinSurface skin_surf(description, aerogel_de, Form("MRICH_aerogel_skin_surface_%d", 1), aerogel_surf, aerogel_vol);
     skin_surf.isValid();
   }
@@ -205,7 +205,7 @@ static Ref_t createDetector(Detector& description, xml::Handle_t e, SensitiveDet
 
     // optical surfaces
     auto lens_surf =
-        surfMgr.opticalSurface(dd4hep::getAttrOrDefault(x_lens, _Unicode(surface), "MRICH_LensOpticalSurface"));
+        surfMgr.opticalSurface(dd4hep::getAttrOrDefault<std::string>(x_lens, _Unicode(surface), "MRICH_LensOpticalSurface"));
     SkinSurface skin_surf(description, lens_de, Form("MRichFresnelLens_skin_surface_%d", 1), lens_surf, lens_vol);
     skin_surf.isValid();
   }
@@ -244,7 +244,7 @@ static Ref_t createDetector(Detector& description, xml::Handle_t e, SensitiveDet
 
     // optical surfaces
     auto mirror_surf =
-        surfMgr.opticalSurface(dd4hep::getAttrOrDefault(x_mirror, _Unicode(surface), "MRICH_MirrorOpticalSurface"));
+        surfMgr.opticalSurface(dd4hep::getAttrOrDefault<std::string>(x_mirror, _Unicode(surface), "MRICH_MirrorOpticalSurface"));
     SkinSurface skin_surf(description, mirror_de, Form("MRICH_mirror_skin_surface_%d", 1), mirror_surf, mirror_vol);
     skin_surf.isValid();
   }

--- a/src/ShashlikCalorimeter_geo.cpp
+++ b/src/ShashlikCalorimeter_geo.cpp
@@ -67,7 +67,7 @@ std::tuple<Volume, int, double, double> build_shashlik(Detector& desc, xml::Coll
 {
   auto mod = plm.child(_Unicode(module));
   // a modular volume
-  std::string shape = dd4hep::getAttrOrDefault(mod, _Unicode(shape), "square");
+  std::string shape = dd4hep::getAttrOrDefault<std::string>(mod, _Unicode(shape), "square");
   std::transform(shape.begin(), shape.end(), shape.begin(), [](char c) { return std::tolower(c); });
   int nsides = 4;
   if (shape == "hexagon") {
@@ -84,7 +84,7 @@ std::tuple<Volume, int, double, double> build_shashlik(Detector& desc, xml::Coll
   // wrapper info
   PolyhedraRegular mpoly(nsides, 0., rmax, len);
   Volume           mvol("shashlik_module_vol", mpoly, desc.air());
-  mvol.setVisAttributes(desc.visAttributes(dd4hep::getAttrOrDefault(mod, _Unicode(vis), "GreenVis")));
+  mvol.setVisAttributes(desc.visAttributes(dd4hep::getAttrOrDefault<std::string>(mod, _Unicode(vis), "GreenVis")));
 
   double gap = 0.;
   Volume wvol("shashlik_wrapper_vol");
@@ -94,7 +94,7 @@ std::tuple<Volume, int, double, double> build_shashlik(Detector& desc, xml::Coll
     if (gap > 1e-6 * mm) {
       wvol.setSolid(PolyhedraRegular(nsides, 0., rmax + gap, len));
       wvol.setMaterial(desc.material(wrap.attr<std::string>(_Unicode(material))));
-      wvol.setVisAttributes(desc.visAttributes(dd4hep::getAttrOrDefault(wrap, _Unicode(vis), "WhiteVis")));
+      wvol.setVisAttributes(desc.visAttributes(dd4hep::getAttrOrDefault<std::string>(wrap, _Unicode(vis), "WhiteVis")));
       wvol.placeVolume(mvol, Position{0., 0., 0.});
     }
   }
@@ -121,14 +121,14 @@ std::tuple<Volume, int, double, double> build_shashlik(Detector& desc, xml::Coll
         PolyhedraRegular spoly(nsides, 0., rmax, sthick);
         Volume           svol(sname, spoly, desc.material(si.attr<std::string>(_Unicode(material))));
 
-        std::string issens = dd4hep::getAttrOrDefault(si, _Unicode(sensitive), "no");
+        std::string issens = dd4hep::getAttrOrDefault<std::string>(si, _Unicode(sensitive), "no");
         std::transform(issens.begin(), issens.end(), issens.begin(), [](char c) { return std::tolower(c); });
         if ((issens == "yes") || (issens == "y") || (issens == "true")) {
           svol.setSensitiveDetector(sens);
         }
-        svol.setAttributes(desc, dd4hep::getAttrOrDefault(si, _Unicode(region), ""),
-                           dd4hep::getAttrOrDefault(si, _Unicode(limits), ""),
-                           dd4hep::getAttrOrDefault(si, _Unicode(vis), "InvisibleNoDaughters"));
+        svol.setAttributes(desc, dd4hep::getAttrOrDefault<std::string>(si, _Unicode(region), ""),
+                           dd4hep::getAttrOrDefault<std::string>(si, _Unicode(limits), ""),
+                           dd4hep::getAttrOrDefault<std::string>(si, _Unicode(vis), "InvisibleNoDaughters"));
 
         // Slice placement.
         auto slicePV = lvol.placeVolume(svol, Position(0, 0, sz + sthick / 2.));
@@ -138,9 +138,9 @@ std::tuple<Volume, int, double, double> build_shashlik(Detector& desc, xml::Coll
       }
 
       // Set region, limitset, and vis of layer.
-      lvol.setAttributes(desc, dd4hep::getAttrOrDefault(li, _Unicode(region), ""),
-                         dd4hep::getAttrOrDefault(li, _Unicode(limits), ""),
-                         dd4hep::getAttrOrDefault(li, _Unicode(vis), "InvisibleNoDaughters"));
+      lvol.setAttributes(desc, dd4hep::getAttrOrDefault<std::string>(li, _Unicode(region), ""),
+                         dd4hep::getAttrOrDefault<std::string>(li, _Unicode(limits), ""),
+                         dd4hep::getAttrOrDefault<std::string>(li, _Unicode(vis), "InvisibleNoDaughters"));
 
       auto layerPV = mvol.placeVolume(lvol, Position(0, 0, lz + lthick / 2));
       layerPV.addPhysVolID("layer", lnum++);


### PR DESCRIPTION
This is needed to support DD4hep built with `-DDD4HEP_USE_XERCESC=ON`.