### PR TITLE
feat: only build-test LCG for ubuntu 20.04

### DIFF
--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -38,39 +38,3 @@ jobs:
         name: build-lcg-ubuntu2004
         path: install/
         if-no-files-found: error
-
-  build-lcg-ubuntu-2204:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        LCG: ["LCG_101/x86_64-ubuntu2004-gcc9-opt"]
-    steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-      with:
-        cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'
-    - uses: aidasoft/run-lcg-view@v1
-      with:
-        release-platform: ${{ matrix.LCG }}
-        run: |
-          PREFIX=${PWD}/install
-          # install ip6 repo
-          git clone https://github.com/eic/ip6.git eic_ip6
-          pushd eic_ip6
-          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX}
-          cmake --build build -- install
-          popd
-          # install this repo
-          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX}
-          cmake --build build -- install
-          # link ip6 into install
-          ln -sf ../ip6/ip6 ${PREFIX}/share/ecce/ip6
-          # check geometry
-          source ${PREFIX}/setup.sh
-          checkGeometry -c ${DETECTOR_PATH}/${DETECTOR}.xml
-    - uses: actions/upload-artifact@v3
-      with:
-        name: build-lcg-ubuntu2204
-        path: install/
-        if-no-files-found: error


### PR DESCRIPTION
There is no difference between ubuntu 20.04 and 22.04 in what concerns LCG. Both use the exact same directories.