### PR TITLE
feat: limit workflows with concurrency

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1,9 +1,12 @@
 name: linux-eic-shell
 
 on:
-- push
 - pull_request
 - workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   xmllint-before-build:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1,8 +1,13 @@
 name: linux-eic-shell
 
 on:
-- pull_request
-- workflow_dispatch
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -1,7 +1,12 @@
 name: linux-lcg
 
 on:
-- pull_request
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -1,6 +1,11 @@
 name: linux-lcg
 
-on: [push, pull_request]
+on:
+- pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-lcg-ubuntu-2004:


### PR DESCRIPTION
In order to limit the number of active or queued workflows, this changes workflows to only run on pull_request and as part of a concurrency group which will cancel in-progress jobs.