### PR TITLE
fix: concentrate sed drops into build-fast-eic-shell artifact

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -193,6 +193,26 @@ jobs:
           noverlaps="$(grep -c ovlp doc/overlap_check_tgeo.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
+  check-overlap-geant4:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        name: build-full-eic-shell
+        path: install/
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        setup: install/setup.sh
+        run: |
+          mkdir -p doc
+          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_geant4.out
+          noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
+          if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
+
   check-overlap-geant4-fast:
     runs-on: ubuntu-latest
     needs: build-test
@@ -235,7 +255,7 @@ jobs:
 
   trigger-detector-benchmarks:
     runs-on: ubuntu-latest
-    needs: [check-overlap-tgeo, check-overlap-geant4]
+    needs: [check-overlap-tgeo, check-overlap-geant4-fast]
     steps:
     - uses: eic/trigger-gitlab-ci@v2
       id: trigger

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -47,7 +47,18 @@ jobs:
           ln -sf ../ip6/ip6 ${PREFIX}/share/ecce/ip6
     - uses: actions/upload-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
+        path: install/
+        if-no-files-found: error
+    - run: |
+        source install/setup.sh
+        sed -i '/<fiber/,+6d' ${DETECTOR_PATH}/compact/ecal_barrel_interlayers.xml
+        sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/compact/ecal_forward_scfi.xml
+        sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
+        sed -i '/<lens/,+4d' ${DETECTOR_PATH}/compact/mrich.xml
+    - uses: actions/upload-artifact@v3
+      with:
+        name: build-fast-eic-shell
         path: install/
         if-no-files-found: error
 
@@ -57,7 +68,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - run: |
         sudo apt-get update
@@ -71,7 +82,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -94,7 +105,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -117,7 +128,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -140,7 +151,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -169,7 +180,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -178,20 +189,18 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          sed -i '/<fiber/,+6d' ${DETECTOR_PATH}/compact/ecal_barrel_interlayers.xml
-          sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
           checkOverlaps -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_tgeo.out
           noverlaps="$(grep -c ovlp doc/overlap_check_tgeo.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
-  check-overlap-geant4:
+  check-overlap-geant4-fast:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-fast-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -200,8 +209,6 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          sed -i '/<fiber/,+6d' ${DETECTOR_PATH}/compact/ecal_barrel_interlayers.xml
-          sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
           python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_geant4.out
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
@@ -213,7 +220,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-full-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -252,7 +259,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-fast-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main


### PR DESCRIPTION
We drop the fibers and the mrich lens for speed, then store that as an artifact for future use in dawn images.