### PR TITLE
dRICH: Parse modified drich xml files (fork PR check)

### DIFF
--- a/templates/ecce.xml.jinja2
+++ b/templates/ecce.xml.jinja2
@@ -118,7 +118,11 @@
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'drich' in features['pid'] %}
-  <include ref="compact/drich.xml"/>
+    {% if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
+    <include ref="compact/drich.xml"/>
+    {% else %}
+    <include ref="{{ features['pid']['drich'] }}"/>
+    {% endif -%}
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'mrich' in features['pid'] %}

--- a/templates/ecce.xml.jinja2
+++ b/templates/ecce.xml.jinja2
@@ -118,11 +118,11 @@
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'drich' in features['pid'] %}
-    {% if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
-    <include ref="compact/drich.xml"/>
-    {% else %}
-    <include ref="{{ features['pid']['drich'] }}"/>
-    {% endif -%}
+  {%- if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
+  <include ref="compact/drich.xml"/>
+  {% else %}
+  <include ref="{{ features['pid']['drich'] }}"/>
+  {% endif -%}
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'mrich' in features['pid'] %}


### PR DESCRIPTION
If the config yaml file is
```
features:
  pid:
    drich:
```
it will use the default `compact/drich.xml`, else if it is
```
features:
  pid:
    drich: my_custom_drich.xml
```
it will instead use `my_custom_drich.xml`